### PR TITLE
Add very minimal Redis cluster support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
+    if: github.repository == 'jazzband/django-redis'
     name: >
       Test Python ${{ matrix.python-version }},
       Django ${{ matrix.django-version }},
@@ -117,6 +118,7 @@ jobs:
           PYTHON: ${{ matrix.python-version }}
 
   lint:
+    if: github.repository == 'jazzband/django-redis'
     name: Lint (${{ matrix.tool }})
     runs-on: ubuntu-latest
 
@@ -165,6 +167,7 @@ jobs:
           flags: mypy
 
   check-changelog:
+    if: github.repository == 'jazzband/django-redis'
     name: Check for news fragments in 'changelog.d/'
     runs-on: ubuntu-latest
 

--- a/README.rst
+++ b/README.rst
@@ -832,6 +832,36 @@ This client exposes additional settings:
 
 - ``CACHE_HERD_TIMEOUT``: Set default herd timeout. (Default value: 60s)
 
+Cluster client
+^^^^^^^^^^^^^^
+
+This pluggable client defaults to using the ``RedisCluster`` client from
+redis-py (introduced in redis-py v4.1.0) in order to connect to a horizontally
+scaled Redis Cluster.
+
+Like previous pluggable clients, it inherits all functionality from the default
+client. Because of the differences between the basic Redis client and the
+``RedisCluster`` client, we will also enforce a default connection-factory class
+here, ``django_redis.pool.ClusterConnectionFactory``, and ignore the
+application-wide ``DJANGO_REDIS_CONNECTION_FACTORY`` setting.
+
+.. code-block:: python
+
+    CACHES = {
+        "default": {
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": "redis://127.0.0.1:6379/1",
+            "OPTIONS": {
+                "CLIENT_CLASS": "django_redis.client.ClusterClient",
+            }
+        }
+    }
+
+The ``django_redis.client.ClusterClient`` doesn't implement any cluster-specific
+commands directly, but if you need the underlying redis-py ``RedisCluster``
+client it is accessible via the ``get_redis_client(...)`` utility.
+
+
 Pluggable serializer
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/django_redis/client/__init__.py
+++ b/django_redis/client/__init__.py
@@ -1,6 +1,13 @@
+from .cluster import ClusterClient
 from .default import DefaultClient
 from .herd import HerdClient
 from .sentinel import SentinelClient
 from .sharded import ShardClient
 
-__all__ = ["DefaultClient", "HerdClient", "SentinelClient", "ShardClient"]
+__all__ = [
+    "ClusterClient",
+    "DefaultClient",
+    "HerdClient",
+    "SentinelClient",
+    "ShardClient",
+]

--- a/django_redis/client/cluster.py
+++ b/django_redis/client/cluster.py
@@ -1,0 +1,16 @@
+from ..pool import ClusterConnectionFactory
+from .default import DefaultClient
+
+
+class ClusterClient(DefaultClient):
+    """A django-redis client compatible with redis.cluster.RedisCluster
+
+    We don't do much different here, except for using our own
+    ClusterConnectionFactory (the base class would instead use the value of the
+    DJANGO_REDIS_CONNECTION_FACTORY setting, but we don't care about that
+    setting here.)
+    """
+
+    def __init__(self, server, params, backend) -> None:
+        super().__init__(server, params, backend)
+        self.connection_factory = ClusterConnectionFactory(options=self._options)

--- a/django_redis/pool.py
+++ b/django_redis/pool.py
@@ -142,7 +142,7 @@ class ClusterConnectionFactory(ConnectionFactory):
 
     # A global cache of URL->client so that within a process, we will reuse a
     # single client, and therefore a single set of connection pools.
-    _clients = {}
+    _clients: Dict[str, RedisCluster] = {}
     _clients_lock = threading.Lock()
 
     def __init__(self, options):


### PR DESCRIPTION
NB: I'm just opening a PR here local to the fork so I can more easily see the GH Actions -- I think that might be my simplest route to maybe adding some minimal clustered-redis test support is to do it in that env instead of on my local machine, 'cause following the tests/README verbatim didn't work for me and I've yet to dig into that very deeply, but seems like GH Actions are working upstream.

---

Basically just enough to make django-redis fit with the redis.cluster.RedisCluster client (which was introduced in redis-py v4.1.0)

For non-clustered Redis, django-redis's ConnectionFactory does some management of connection pools shared between client instances. The cluster client in redis-py, though, doesn't accept a connection pool from outside, they're managed internally. To support that, we won't be caching connection pools and passing them into clients, we will instead be caching client instances.